### PR TITLE
new session when user updates identity

### DIFF
--- a/test/plugins/api/users.js
+++ b/test/plugins/api/users.js
@@ -691,7 +691,7 @@ lab.experiment('Users Plugin (My) Update', function () {
             var args = Array.prototype.slice.call(arguments);
             var callback = args.pop();
 
-            callback(null, {});
+            callback(null, [{}, {}]);
         };
 
         server.inject(request, function (response) {


### PR DESCRIPTION
When a user updates their own username/email, we need to give them a new session as the current one could be invalidated after the update.
