### PR TITLE
Added url for BaseModel.connect which fixes the failing setup.js

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -118,7 +118,7 @@ Async.auto({
         Async.auto({
             connect: function (done) {
 
-                BaseModel.connect(done);
+                BaseModel.connect({ url: results.mongodbUrl }, done);
             },
             clean: ['connect', function (done) {
 


### PR DESCRIPTION
`BaseModel.connect` did not have a mongo url to connect and was failing. This adds the url from the config process and allows a connection to complete the setup of the root user.
