### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "frame",
   "version": "3.1.0",
   "description": "A user system API for Node.js",
+  "homepage": "http://jedireza.github.io/frame/",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jedireza/frame.git"
+  },
+  "keywords": [
+    "hapi",
+    "authentication"
+  ],
   "scripts": {
     "setup": "./setup.js",
     "start": "./node_modules/nodemon/bin/nodemon.js -e js,md server",
@@ -11,6 +20,9 @@
   },
   "author": "Reza Akhavan <jedireza@gmail.com> (http://reza.akhavan.me/)",
   "license": "MIT",
+  "engines": {
+    "node": "^0.10.32"
+  },
   "dependencies": {
     "async": "^0.9.0",
     "bcrypt": "^0.8.0",


### PR DESCRIPTION
When doing npm install:
"npm WARN package.json frame@3.1.0 No repository field."

https://docs.npmjs.com/files/package.json#repository

Not finding when I search npm.
https://docs.npmjs.com/files/package.json#keywords

Heroku will complain if "engines" isn't specified.
https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version