### PR TITLE
Examples of fleshing out much needed documentation through Hapi-Swagger / Joi schema updates

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -70,10 +70,46 @@ const manifest = {
                 options: {
                     info: {
                         title: 'Frame API Documentation',
-                        version: Package.version
+                        version: Package.version,
+                        description: `A brief recap of what is covered by these endpoints. What's the difference between /api/accounts and /api/users? What is /api/stasues for? What are the default role policies put into place? Like who can call /api/admins? Some of those things could be answered in the description of the actual endpoints but it would be great to have a short overview here for folks to quickly get up to speed and answer common questions.
+                         Here's a link to the **[Github Wiki](https://github.com/jedireza/frame/wiki)** for other common questions and how-tos.`
                     },
                     grouping: 'tags',
-                    sortTags: 'name'
+                    sortTags: 'name',
+                		tags: [{
+                			'name': 'accounts',
+                			'description': 'endpoints that deal with user account management?'
+                		},{
+                			'name': 'admin-groups',
+                			'description': 'endpoints for interacting with admin groups?'
+                		},{
+                      'name': 'admins',
+                      'description': 'endpoints that deal with individual admins?'
+                    },{
+                			'name': 'contact',
+                			'description': 'endpoints for user contact form?'
+                    },{
+                			'name': 'login',
+                			'description': 'endpoints for user login'
+                    },{
+                			'name': 'logout',
+                			'description': 'endpoints for user logout'
+                    },{
+                			'name': 'main',
+                			'description': 'endpoints for main? No idea.'
+                    },{
+                			'name': 'session',
+                			'description': 'endpoints around user sessions'
+                    },{
+                			'name': 'signup',
+                			'description': 'endpoints for user signup'
+                    },{
+                			'name': 'statuses',
+                			'description': 'endpoints for user statuses (what are user statuses?)'
+                    },{
+                			'name': 'users',
+                			'description': 'endpoints around user objects'
+                    }]
                 }
             },
             {

--- a/server/api/accounts.js
+++ b/server/api/accounts.js
@@ -21,9 +21,9 @@ const register = function (server, serverOptions) {
             },
             validate: {
                 query: {
-                    sort: Joi.string().default('_id'),
-                    limit: Joi.number().default(20),
-                    page: Joi.number().default(1)
+                    sort: Joi.string().default('_id').description('This is a description for this query parameter. This is obviously a sort but what are the allowed values in the default setup? I\'ve added an example allow() validation which will show up as a pick list in interactive docs.').allow('_id', '_option2', '_option3'),
+                    limit: Joi.number().integer().default(20).description('I\'m assuming this is how many results you want at a time per page? We should mention that just so it\'s clear. It should also have min/max Joi validation which also shows up in docs. I\'ve added an example.').min(1).max(1000),
+                    page: Joi.number().integer().default(1).description('Looks like default is 1 so this is a 1 based index not a zero based index right? We should state stuff like that here.').min(1).max(1000)
                 }
             }
         },

--- a/server/api/accounts.js
+++ b/server/api/accounts.js
@@ -16,6 +16,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts',
         options: {
             tags: ['api','accounts'],
+            description: 'Get a paginated list of all accounts (need admin role)',
+            notes: 'This endpoint returns a paginated list of accounts that have been created. This is a much longer detailed description if we have answers to common questions, but I mainly have questions. Whats the difference between accounts and users? When would you want to list all accounts instead of all users? Assuming you need an admin role to use this endpoint? Where is that configured?',
             auth: {
                 scope: 'admin'
             },
@@ -25,6 +27,13 @@ const register = function (server, serverOptions) {
                     limit: Joi.number().integer().default(20).description('I\'m assuming this is how many results you want at a time per page? We should mention that just so it\'s clear. It should also have min/max Joi validation which also shows up in docs. I\'ve added an example.').min(1).max(1000),
                     page: Joi.number().integer().default(1).description('Looks like default is 1 so this is a 1 based index not a zero based index right? We should state stuff like that here.').min(1).max(1000)
                 }
+            },
+            response: {
+              schema: Joi.object({
+                results: Joi.array().items(
+                  Account.schema
+                ).label('Array of Account objects').required()
+              }).label('Accounts List Response Model').description('Returns a list of accounts.')
             }
         },
         handler: async function (request, h) {

--- a/server/models/account.js
+++ b/server/models/account.js
@@ -27,6 +27,23 @@ const schema = Joi.object({
         id: Joi.string().required(),
         name: Joi.string().lowercase().required()
     })
+}).label('Account object').example({
+  _id: {asdf: 'asdf'},
+  name: {
+      first: 'John',
+      middle: 'Doe',
+      last: 'Smith'
+  },
+  notes: [ NoteEntry.schema._examples[0] ],
+  status: {
+      current: StatusEntry.schema._examples[0],
+      log: [StatusEntry.schema._examples[0]]
+  },
+  timeCreated: '2018-05-23T20:19:27Z',
+  user: {
+      id: 'asdfsadffds',
+      name: 'username?'
+  }
 });
 
 

--- a/server/models/note-entry.js
+++ b/server/models/note-entry.js
@@ -11,7 +11,14 @@ const schema = Joi.object({
     }).required(),
     data: Joi.string().required(),
     timeCreated: Joi.date().default(NewDate(), 'time of creation')
-});
+}).label('Note Entry object').example({
+  adminCreated: {
+    id: 'asdfsdf',
+    name: 'asdfsfdsf'
+  },
+  data: 'asdfsfsdsf',
+  timeCreated: NewDate()
+})
 
 
 class NoteEntry extends MongoModels {}

--- a/server/models/status-entry.js
+++ b/server/models/status-entry.js
@@ -12,6 +12,14 @@ const schema = Joi.object({
         id: Joi.string().required(),
         name: Joi.string().required()
     }).required()
+}).label('Status-Entry object').example({
+    id: 'asfsfsdf',
+    name: 'asfsdsfsf',
+    timeCreated: '2018-05-23T20:19:27Z',
+    adminCreated: {
+        id: 'asdfsadffds',
+        name: 'username?'
+    }
 });
 
 


### PR DESCRIPTION
Hi Reza,
Here are 3 examples of documentation updates I'd recommend through Hapi-Swagger / Joi Schema updates. 

The first example commit adds a description field below the Swagger.json / Swagger UI title. I added an example of the type of documentation summary that would be great to include there. I also added tag descriptions so that each category of endpoints can have a brief description about what that category is for. It looks like this in rendered documentation: 
https://www.dropbox.com/s/xanfh27wgrrlxus/Screenshot%202018-05-23%2014.00.46.png?dl=0

The second commit is an example of taking it a bit further, it looks like this:
https://www.dropbox.com/s/fz2nr2u2h4qz1t2/Screenshot%202018-05-23%2013.59.09.png?dl=0
Adding descriptions to your endpoints and endpoint parameters via updates to the endpoint route definition Joi object schema you're already using. route.options.description is super useful here in that it shows up as a brief summary of each endpoint even when collapsed in documentation. route.options.notes is the big one to fill out to fully brain dump what the endpoint technically does, use cases and things to look out for (admin role needed) etc. 
I also added an example of adding some more Joi validation options that were missing, like adding an allow() with the actual options available for "sort".  This conveniently shows up as dropdown options in the interactive version of your Swagger documentation. 

The third commit is an example of taking it a bit further still. Hooking up response schema to the joi validation on your endpoints. This has the benefit of actually enforcing validation on endpoint responses (and sending an http 500 if you don't get what you expect, good security option) but is most useful to actually show the sample response AND response schema in the swagger.json / Swagger UI. Here is what that would look like:
https://www.dropbox.com/s/w9acp2smqlqldal/Screenshot%202018-05-23%2014.01.36.png?dl=0
I noticed you already have model files defined with Joi object schema so I tap into and re-use those to generate this. 

Let me know what you think! If we were able to get these kinds of updates in place the docs for this would be amazing and I think the project would take off far greater than it has. You could display the interactive documentation link more prominently and everyone would have their questions answered simply by interacting with it: https://getframe.herokuapp.com/documentation

These commits are just placeholders for where the real data should be, I'm game to help fill everything out but have more questions then answers on pretty much every endpoint besides basic signup and login. Let me know if I can help with anything else in particular.

