### PR TITLE
Add swagger docs metadata

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -87,10 +87,11 @@ This role contains a "name" (first, middle, last), "permissions", and "groups" p
 
 More details on [Users, Roles & Groups](https://github.com/jedireza/frame/wiki/Users,-Roles-&-Groups)   
 More details on [Admin & Admin Group Permissions](https://github.com/jedireza/frame/wiki/Admin-&-Admin-Group-Permissions)`
-                        },
-                        grouping: 'tags',
-                        sortTags: 'name',
-                        tags: [{
+                    },
+                    grouping: 'tags',
+                    sortTags: 'name',
+                    tags: [
+                        {
                             name: 'accounts',
                             description: 'endpoints to interact with customer role.'
                         },{
@@ -119,9 +120,10 @@ More details on [Admin & Admin Group Permissions](https://github.com/jedireza/fr
                         },{
                             name: 'users',
                             description: 'endpoints to interact with users (outside of roles)'
-                        }]
-                    }
-                },
+                        }
+                    ]
+                }
+            },
             {
                 plugin: 'hapi-mongo-models',
                 options: {

--- a/manifest.js
+++ b/manifest.js
@@ -70,10 +70,56 @@ const manifest = {
                 options: {
                     info: {
                         title: 'Frame API Documentation',
-                        version: Package.version
+                        version: Package.version,
+                        description: `Check out the **[Github Wiki](https://github.com/jedireza/frame/wiki)** for common questions and how-tos.
+   
+A few key things to be aware of:   
+The core User model found in the /api/users/ endpoints have these basic fields: _id, email, username, password, isActive, roles, timeCreated.
+   
+This framework decorates the core User models with additional role specific fields via mapping it to 1 or more roles. Frame comes with 2 default roles, customers and admins.    
+
+/api/accounts/ is the "customer account" role.    
+When users sign up via /api/signup the framework automatically creates a new User and a new Account (aka customer role) and links the two. Users can have multiple roles but each new instance of a role model can only be mapped to one user.
+The customer Account role adds these additional fields for users who are customers: "name" (first, middle last), "notes", and "status". "Notes" allows admins to add notes to accounts.
+   
+/api/admins/ is the "admin" role.   
+This role contains a "name" (first, middle, last), "permissions", and "groups" property allowing you to assign multiple admin-groups. The first admin-group is "root" which is allowed to perform the "Root Scope" actions.
+
+More details on [Users, Roles & Groups](https://github.com/jedireza/frame/wiki/Users,-Roles-&-Groups)   
+More details on [Admin & Admin Group Permissions](https://github.com/jedireza/frame/wiki/Admin-&-Admin-Group-Permissions)`
                     },
                     grouping: 'tags',
-                    sortTags: 'name'
+                    sortTags: 'name',
+                		tags: [{
+                			name: 'accounts',
+                			description: 'endpoints to interact with customer role.'
+                		},{
+                			name: 'admin-groups',
+                			description: 'endpoints to interact with admin groups.'
+                		},{
+                      name: 'admins',
+                      description: 'endpoints to interact with admin roles.'
+                    },{
+                			name: 'contact'
+                    },{
+                			name: 'login',
+                      description: 'endpoints for login flow.'
+                    },{
+                			name: 'logout'
+                    },{
+                			name: 'main'
+                    },{
+                			name: 'session',
+                			description: 'endpoints to interact with user sessions.'
+                    },{
+                			name: 'signup'
+                    },{
+                			name: 'statuses',
+                			description: 'endpoints to interact with customer role (account) statuses.'
+                    },{
+                			name: 'users',
+                			description: 'endpoints to interact with users (outside of roles)'
+                    }]
                 }
             },
             {

--- a/manifest.js
+++ b/manifest.js
@@ -87,41 +87,41 @@ This role contains a "name" (first, middle, last), "permissions", and "groups" p
 
 More details on [Users, Roles & Groups](https://github.com/jedireza/frame/wiki/Users,-Roles-&-Groups)   
 More details on [Admin & Admin Group Permissions](https://github.com/jedireza/frame/wiki/Admin-&-Admin-Group-Permissions)`
-                    },
-                    grouping: 'tags',
-                    sortTags: 'name',
-                		tags: [{
-                			name: 'accounts',
-                			description: 'endpoints to interact with customer role.'
-                		},{
-                			name: 'admin-groups',
-                			description: 'endpoints to interact with admin groups.'
-                		},{
-                      name: 'admins',
-                      description: 'endpoints to interact with admin roles.'
-                    },{
-                			name: 'contact'
-                    },{
-                			name: 'login',
-                      description: 'endpoints for login flow.'
-                    },{
-                			name: 'logout'
-                    },{
-                			name: 'main'
-                    },{
-                			name: 'session',
-                			description: 'endpoints to interact with user sessions.'
-                    },{
-                			name: 'signup'
-                    },{
-                			name: 'statuses',
-                			description: 'endpoints to interact with customer role (account) statuses.'
-                    },{
-                			name: 'users',
-                			description: 'endpoints to interact with users (outside of roles)'
-                    }]
-                }
-            },
+                        },
+                        grouping: 'tags',
+                        sortTags: 'name',
+                        tags: [{
+                            name: 'accounts',
+                            description: 'endpoints to interact with customer role.'
+                        },{
+                            name: 'admin-groups',
+                            description: 'endpoints to interact with admin groups.'
+                        },{
+                            name: 'admins',
+                            description: 'endpoints to interact with admin roles.'
+                        },{
+                            name: 'contact'
+                        },{
+                            name: 'login',
+                            description: 'endpoints for login flow.'
+                        },{
+                            name: 'logout'
+                        },{
+                            name: 'main'
+                        },{
+                            name: 'session',
+                            description: 'endpoints to interact with user sessions.'
+                        },{
+                            name: 'signup'
+                        },{
+                            name: 'statuses',
+                            description: 'endpoints to interact with customer role (account) statuses.'
+                        },{
+                            name: 'users',
+                            description: 'endpoints to interact with users (outside of roles)'
+                        }]
+                    }
+                },
             {
                 plugin: 'hapi-mongo-models',
                 options: {

--- a/server/api/accounts.js
+++ b/server/api/accounts.js
@@ -16,14 +16,16 @@ const register = function (server, serverOptions) {
         path: '/api/accounts',
         options: {
             tags: ['api','accounts'],
+            description: 'Get a paginated list of all customer accounts. [Admin Scope]',
+            notes: 'Get a paginated list of all customer accounts.',
             auth: {
                 scope: 'admin'
             },
             validate: {
                 query: {
-                    sort: Joi.string().default('_id'),
-                    limit: Joi.number().default(20),
-                    page: Joi.number().default(1)
+                  sort: Joi.string().default('_id'),
+                  limit: Joi.number().default(20),
+                  page: Joi.number().default(1)
                 }
             }
         },
@@ -46,6 +48,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts',
         options: {
             tags: ['api','accounts'],
+            description: 'Create a new customer account. [Admin Scope]',
+            notes: 'Create a new customer account.',
             auth: {
                 scope: 'admin'
             },
@@ -67,6 +71,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/{id}',
         options: {
             tags: ['api','accounts'],
+            description: 'Get a customer account by ID. [Admin Scope]',
+            notes: 'Get a customer account by ID.',
             auth: {
                 scope: 'admin'
             }
@@ -89,6 +95,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/{id}',
         options: {
             tags: ['api','accounts'],
+            description: 'Update a customer account by ID. [Admin Scope]',
+            notes: 'Update a customer account by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -126,6 +134,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/{id}',
         options: {
             tags: ['api','accounts'],
+            description: 'Delete a customer account by ID. [Root Scope]',
+            notes: 'Delete a customer account by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -151,6 +161,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/{id}/user',
         options: {
             tags: ['api','accounts'],
+            description: 'Link a system user to a customer account. [Admin Scope]',
+            notes: 'Link a system user to a customer account.',
             auth: {
                 scope: 'admin'
             },
@@ -217,6 +229,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/{id}/user',
         options: {
             tags: ['api','accounts'],
+            description: 'Unlink a system user to a customer account. [Admin Scope]',
+            notes: 'Unlink a system user to a customer account.',
             auth: {
                 scope: 'admin'
             },
@@ -269,6 +283,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/{id}/notes',
         options: {
             tags: ['api','accounts'],
+            description: 'Add a new note on a customer account. [Admin Scope]',
+            notes: 'Add a new note on a customer account.',
             auth: {
                 scope: 'admin'
             },
@@ -310,6 +326,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/{id}/status',
         options: {
             tags: ['api','accounts'],
+            description: 'Update customer account status by ID. [Admin Scope]',
+            notes: 'Update customer account status by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -368,6 +386,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/my',
         options: {
             tags: ['api','accounts'],
+            description: 'Get the logged-in user\'s account details. [User Account Scope]',
+            notes: 'Get the logged-in user\'s account details.',
             auth: {
                 scope: 'account'
             }
@@ -387,6 +407,8 @@ const register = function (server, serverOptions) {
         path: '/api/accounts/my',
         options: {
             tags: ['api','accounts'],
+            description: 'Update the logged-in user\'s account details. [User Account Scope]',
+            notes: 'Update your account details.',
             auth: {
                 scope: 'account'
             },

--- a/server/api/accounts.js
+++ b/server/api/accounts.js
@@ -23,9 +23,9 @@ const register = function (server, serverOptions) {
             },
             validate: {
                 query: {
-                  sort: Joi.string().default('_id'),
-                  limit: Joi.number().default(20),
-                  page: Joi.number().default(1)
+                    sort: Joi.string().default('_id'),
+                    limit: Joi.number().default(20),
+                    page: Joi.number().default(1)
                 }
             }
         },

--- a/server/api/admin-groups.js
+++ b/server/api/admin-groups.js
@@ -12,6 +12,8 @@ const register = function (server, serverOptions) {
         path: '/api/admin-groups',
         options: {
             tags: ['api','admin-groups'],
+            description: 'Get a paginated list of all admin groups. [Root Scope]',
+            notes: 'Get a paginated list of all admin groups.',
             auth: {
                 scope: 'admin'
             },
@@ -45,6 +47,8 @@ const register = function (server, serverOptions) {
         path: '/api/admin-groups',
         options: {
             tags: ['api','admin-groups'],
+            description: 'Create a new admin group. [Root Scope]',
+            notes: 'Create a new admin group.',
             auth: {
                 scope: 'admin'
             },
@@ -69,6 +73,8 @@ const register = function (server, serverOptions) {
         path: '/api/admin-groups/{id}',
         options: {
             tags: ['api','admin-groups'],
+            description: 'Get an admin group by ID. [Root Scope]',
+            notes: 'Get an admin group by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -94,6 +100,8 @@ const register = function (server, serverOptions) {
         path: '/api/admin-groups/{id}',
         options: {
             tags: ['api','admin-groups'],
+            description: 'Update an admin group by ID. [Root Scope]',
+            notes: 'Update an admin group by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -133,6 +141,8 @@ const register = function (server, serverOptions) {
         path: '/api/admin-groups/{id}',
         options: {
             tags: ['api','admin-groups'],
+            description: 'Delete an admin group by ID. [Root Scope]',
+            notes: 'Delete an admin group by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -163,6 +173,8 @@ const register = function (server, serverOptions) {
         path: '/api/admin-groups/{id}/permissions',
         options: {
             tags: ['api','admin-groups'],
+            description: 'Update an admin group\'s permissions. [Root Scope]',
+            notes: 'Update an admin group\'s permissions.',
             auth: {
                 scope: 'admin'
             },

--- a/server/api/admins.js
+++ b/server/api/admins.js
@@ -13,6 +13,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins',
         options: {
             tags: ['api','admins'],
+            description: 'Get a paginated list of all admin accounts. [Root Scope]',
+            notes: 'Get a paginated list of all admin accounts.',
             auth: {
                 scope: 'admin'
             },
@@ -46,6 +48,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins',
         options: {
             tags: ['api','admins'],
+            description: 'Create a new admin account. [Root Scope]',
+            notes: 'Create a new admin account.',
             auth: {
                 scope: 'admin'
             },
@@ -70,6 +74,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins/{id}',
         options: {
             tags: ['api','admins'],
+            description: 'Get an admin account by ID. [Root Scope]',
+            notes: 'Get an admin account by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -95,6 +101,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins/{id}',
         options: {
             tags: ['api','admins'],
+            description: 'Update an admin account by ID. [Root Scope]',
+            notes: 'Update an admin account by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -137,6 +145,9 @@ const register = function (server, serverOptions) {
         method: 'DELETE',
         path: '/api/admins/{id}',
         options: {
+            tags: ['api','admins'],
+            description: 'Delete an admin account by ID. [Root Scope]',
+            notes: 'Delete an admin account by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -162,6 +173,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins/{id}/groups',
         options: {
             tags: ['api','admins'],
+            description: 'Update an admin account\'s groups by ID. [Root Scope]',
+            notes: 'Update an admin account\'s groups by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -201,6 +214,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins/{id}/permissions',
         options: {
             tags: ['api','admins'],
+            description: 'Update an admin account\'s custom permissions by ID. [Root Scope]',
+            notes: 'Update an admin account\'s custom permissions by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -240,6 +255,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins/{id}/user',
         options: {
             tags: ['api','admins'],
+            description: 'Link an admin account to a user account. [Root Scope]',
+            notes: 'Link an admin account to a user account.',
             auth: {
                 scope: 'admin'
             },
@@ -312,6 +329,8 @@ const register = function (server, serverOptions) {
         path: '/api/admins/{id}/user',
         options: {
             tags: ['api','admins'],
+            description: 'Unlink an admin account from a user account. [Root Scope]',
+            notes: 'Unlink an admin account from a user account.',
             auth: {
                 scope: 'admin'
             },

--- a/server/api/contact.js
+++ b/server/api/contact.js
@@ -11,6 +11,8 @@ const register = function (server, serverOptions) {
         path: '/api/contact',
         options: {
             tags: ['api','contact'],
+            description: 'Generate a contact email. [No Scope]',
+            notes: 'Generate a contact email.',
             auth: false,
             validate: {
                 payload: {

--- a/server/api/login.js
+++ b/server/api/login.js
@@ -16,6 +16,8 @@ const register = function (server, serverOptions) {
         path: '/api/login',
         options: {
             tags: ['api','login'],
+            description: 'Log in with username and password. [No Scope]',
+            notes: 'Log in with username and password.',
             auth: false,
             validate: {
                 payload: {
@@ -91,6 +93,9 @@ const register = function (server, serverOptions) {
         method: 'POST',
         path: '/api/login/forgot',
         options: {
+            tags: ['api','login'],
+            description: 'Trigger forgot password email. [No Scope]',
+            notes: 'Trigger forgot password email.',
             auth: false,
             validate: {
                 payload: {
@@ -151,6 +156,9 @@ const register = function (server, serverOptions) {
         method: 'POST',
         path: '/api/login/reset',
         options: {
+            tags: ['api','login'],
+            description: 'Reset password with forgot password key. [No Scope]',
+            notes: 'Reset password with forgot password key.',
             auth: false,
             validate: {
                 payload: {

--- a/server/api/logout.js
+++ b/server/api/logout.js
@@ -9,6 +9,8 @@ const register = function (server, serverOptions) {
         path: '/api/logout',
         options: {
             tags: ['api','logout'],
+            description: 'Delete the user\'s logged-in session. [User Account Scope]',
+            notes: 'Delete the user\'s logged-in session.',
             auth: {
                 mode: 'try'
             }

--- a/server/api/main.js
+++ b/server/api/main.js
@@ -8,6 +8,8 @@ const register = function (server, serverOptions) {
         path: '/api',
         options: {
             tags: ['api','main'],
+            description: 'Test if API is accessible. [No Scope]',
+            notes: 'Test if API is accessible.',
             auth: false
         },
         handler: function (request, h) {

--- a/server/api/sessions.js
+++ b/server/api/sessions.js
@@ -12,6 +12,8 @@ const register = function (server, serverOptions) {
         path: '/api/sessions',
         options: {
             tags: ['api','session'],
+            description: 'Get a paginated list of all user sessions. [Root Scope]',
+            notes: 'Get a paginated list of all user sessions.',
             auth: {
                 scope: 'admin'
             },
@@ -45,6 +47,8 @@ const register = function (server, serverOptions) {
         path: '/api/sessions/{id}',
         options: {
             tags: ['api','session'],
+            description: 'Get a user session by ID. [Root Scope]',
+            notes: 'Get a user session by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -70,6 +74,8 @@ const register = function (server, serverOptions) {
         path: '/api/sessions/{id}',
         options: {
             tags: ['api','session'],
+            description: 'Delete a user session by ID. [Root Scope]',
+            notes: 'Delete a user session by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -95,6 +101,8 @@ const register = function (server, serverOptions) {
         path: '/api/sessions/my',
         options: {
             tags: ['api','session'],
+            description: 'Get the logged-in user\'s session. [User Account Scope]',
+            notes: 'Get the logged-in user\'s session.',
             auth: {
                 scope: ['admin', 'account']
             }

--- a/server/api/signup.js
+++ b/server/api/signup.js
@@ -15,6 +15,8 @@ const register = function (server, serverOptions) {
         path: '/api/signup',
         options: {
             tags: ['api','signup'],
+            description: 'Sign up for a new user account. [No Scope]',
+            notes: 'Sign up for a new user account. Creates a new User, new Account, and links the two.',
             auth: false,
             validate: {
                 payload: {

--- a/server/api/statuses.js
+++ b/server/api/statuses.js
@@ -12,6 +12,8 @@ const register = function (server, serverOptions) {
         path: '/api/statuses',
         options: {
             tags: ['api','statuses'],
+            description: 'Get a paginated list of all statuses. [Root Scope]',
+            notes: 'Get a paginated list of all statuses.',
             auth: {
                 scope: 'admin'
             },
@@ -45,6 +47,8 @@ const register = function (server, serverOptions) {
         path: '/api/statuses',
         options: {
             tags: ['api','statuses'],
+            description: 'Add a new status. [Root Scope]',
+            notes: 'Add a new status.',
             auth: {
                 scope: 'admin'
             },
@@ -70,6 +74,8 @@ const register = function (server, serverOptions) {
         path: '/api/statuses/{id}',
         options: {
             tags: ['api','statuses'],
+            description: 'Get a status by ID. [Root Scope]',
+            notes: 'Get a status by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -95,6 +101,8 @@ const register = function (server, serverOptions) {
         path: '/api/statuses/{id}',
         options: {
             tags: ['api','statuses'],
+            description: 'Update a status by ID. [Root Scope]',
+            notes: 'Update a status by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -131,6 +139,8 @@ const register = function (server, serverOptions) {
         path: '/api/statuses/{id}',
         options: {
             tags: ['api','statuses'],
+            description: 'Delete a status by ID. [Root Scope]',
+            notes: 'Delete a status by ID.',
             auth: {
                 scope: 'admin'
             },

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -14,6 +14,8 @@ const register = function (server, serverOptions) {
         path: '/api/users',
         options: {
             tags: ['api','users'],
+            description: 'Get a paginated list of all users. [Root Scope]',
+            notes: 'Get a paginated list of all users.',
             auth: {
                 scope: 'admin'
             },
@@ -47,6 +49,8 @@ const register = function (server, serverOptions) {
         path: '/api/users',
         options: {
             tags: ['api','users'],
+            description: 'Create a new user. [Root Scope]',
+            notes: 'Create a new user. This does not map this user to an account.',
             auth: {
                 scope: 'admin'
             },
@@ -102,6 +106,8 @@ const register = function (server, serverOptions) {
         path: '/api/users/{id}',
         options: {
             tags: ['api','users'],
+            description: 'Get a user by ID. [Root Scope]',
+            notes: 'Get a user by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -127,6 +133,8 @@ const register = function (server, serverOptions) {
         path: '/api/users/{id}',
         options: {
             tags: ['api','users'],
+            description: 'Update a user by ID. [Root Scope]',
+            notes: 'Update a user by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -215,6 +223,8 @@ const register = function (server, serverOptions) {
         path: '/api/users/{id}',
         options: {
             tags: ['api','users'],
+            description: 'Delete a user by ID. [Root Scope]',
+            notes: 'Delete a user by ID.',
             auth: {
                 scope: 'admin'
             },
@@ -245,6 +255,8 @@ const register = function (server, serverOptions) {
         path: '/api/users/{id}/password',
         options: {
             tags: ['api','users'],
+            description: 'Update a user password. [Root Scope]',
+            notes: 'Update a user password.',
             auth: {
                 scope: 'admin'
             },
@@ -284,6 +296,8 @@ const register = function (server, serverOptions) {
         path: '/api/users/my',
         options: {
             tags: ['api','users'],
+            description: 'Get the logged-in user\'s user details like roles. [User Account Scope]',
+            notes: 'Get the logged-in user\'s user details like roles.',
             auth: {
                 scope: ['admin', 'account']
             }
@@ -303,6 +317,8 @@ const register = function (server, serverOptions) {
         path: '/api/users/my',
         options: {
             tags: ['api','users'],
+            description: 'Update the logged-in user\'s user details like username and email. [User Account Scope]',
+            notes: 'Update the logged-in user\'s user details like username and email.',
             auth: {
                 scope: ['admin', 'account']
             },
@@ -385,6 +401,8 @@ const register = function (server, serverOptions) {
         path: '/api/users/my/password',
         options: {
             tags: ['api','users'],
+            description: 'Update the logged-in user\'s password. [User Account Scope]',
+            notes: 'Update the logged-in user\'s password.',
             auth: {
                 scope: ['admin', 'account']
             },


### PR DESCRIPTION
Per our discussion I added real and very helpful Swagger doc metadata updates. I didn't add any endpoint Joi schema updates only helpful description fields at the document level, tag level, and endpoint level including helpful scope information. This is what it looks like in the live Swagger UI available at /documentation when deployed: https://www.dropbox.com/s/33wabeyxu446rhf/Screenshot%202018-05-30%2011.55.16.png?dl=0